### PR TITLE
Change the behavior of `step` and `include`

### DIFF
--- a/proofs/examples/programs.smt2
+++ b/proofs/examples/programs.smt2
@@ -16,28 +16,28 @@
 (declare-const c3 Bool)
 
 ; Test removeRight
-(step rr1 :rule is_equals :premises () :args ((removeRight c1 (or c2 c1)) c2))
-(step rr2 :rule is_equals :premises () :args ((removeRight c1 (or c1 c2)) c2))
-(step rr3 :rule is_equals :premises () :args ((removeRight c1 (or c1 (or c2 c3))) (or c2 c3)))
-(step rr4 :rule is_equals :premises () :args ((removeRight c1 (or c2 (or c1 c3))) (or c2 c3)))
-(step rr5 :rule is_equals :premises () :args ((removeRight c1 (or c2 (or c3 c2))) (or c2 c3)))
+(step rr1 :rule is_equals :args ((removeRight c1 (or c2 c1)) c2))
+(step rr2 :rule is_equals :args ((removeRight c1 (or c1 c2)) c2))
+(step rr3 :rule is_equals :args ((removeRight c1 (or c1 (or c2 c3))) (or c2 c3)))
+(step rr4 :rule is_equals :args ((removeRight c1 (or c2 (or c1 c3))) (or c2 c3)))
+(step rr5 :rule is_equals :args ((removeRight c1 (or c2 (or c3 c2))) (or c2 c3)))
 
 ; Test appendRight
-(step ar1 :rule is_equals :premises () :args ((appendRight or c1 c2) (or c1 c2)))
-(step ar2 :rule is_equals :premises () :args ((appendRight or c3 (or c1 c2))         (or c1 (or c2 c3))))
-(step ar3 :rule is_equals :premises () :args ((appendRight or c3 (or (or c1 c1) c2)) (or (or c1 c1) (or c2 c3))))
-(step ar4 :rule is_equals :premises () :args ((appendRight or c3 (or c1 (or c1 c2))) (or c1 (or c1 (or c2 c3)))))
+(step ar1 :rule is_equals :args ((appendRight or c1 c2) (or c1 c2)))
+(step ar2 :rule is_equals :args ((appendRight or c3 (or c1 c2))         (or c1 (or c2 c3))))
+(step ar3 :rule is_equals :args ((appendRight or c3 (or (or c1 c1) c2)) (or (or c1 c1) (or c2 c3))))
+(step ar4 :rule is_equals :args ((appendRight or c3 (or c1 (or c1 c2))) (or c1 (or c1 (or c2 c3)))))
 
 ; Test removeLeft
-(step rl1 :rule is_equals :premises () :args ((removeLeft c1 (or c2 c1)) c2))
-(step rl2 :rule is_equals :premises () :args ((removeLeft c1 (or c1 c2)) c2))
-(step rl3 :rule is_equals :premises () :args ((removeLeft c1 (or (or c1 c2) c3)) (or c2 c3)))
-(step rl4 :rule is_equals :premises () :args ((removeLeft c1 (or (or c2 c1) c3)) (or c2 c3)))
-(step rl5 :rule is_equals :premises () :args ((removeLeft c1 (or (or c2 c3) c2)) (or c2 c3)))
+(step rl1 :rule is_equals :args ((removeLeft c1 (or c2 c1)) c2))
+(step rl2 :rule is_equals :args ((removeLeft c1 (or c1 c2)) c2))
+(step rl3 :rule is_equals :args ((removeLeft c1 (or (or c1 c2) c3)) (or c2 c3)))
+(step rl4 :rule is_equals :args ((removeLeft c1 (or (or c2 c1) c3)) (or c2 c3)))
+(step rl5 :rule is_equals :args ((removeLeft c1 (or (or c2 c3) c2)) (or c2 c3)))
 
 ; Test appendLeft
-(step al1 :rule is_equals :premises () :args ((appendLeft or c1 c2) (or c1 c2)))
-(step al2 :rule is_equals :premises () :args ((appendLeft or c3 (or c1 c2)        ) (or (or c3 c1) c2)))
-(step al3 :rule is_equals :premises () :args ((appendLeft or c3 (or (or c1 c1) c2)) (or (or (or c3 c1) c1) c2)))
-(step al4 :rule is_equals :premises () :args ((appendLeft or c3 (or c1 (or c1 c2))) (or (or c3 (or c1 c1)) c2)))
+(step al1 :rule is_equals :args ((appendLeft or c1 c2) (or c1 c2)))
+(step al2 :rule is_equals :args ((appendLeft or c3 (or c1 c2)        ) (or (or c3 c1) c2)))
+(step al3 :rule is_equals :args ((appendLeft or c3 (or (or c1 c1) c2)) (or (or (or c3 c1) c1) c2)))
+(step al4 :rule is_equals :args ((appendLeft or c3 (or c1 (or c1 c2))) (or (or c3 (or c1 c1)) c2)))
 

--- a/proofs/examples/programs.smt2
+++ b/proofs/examples/programs.smt2
@@ -1,6 +1,6 @@
 ; Tests for the gerneral programs.
 
-(include "./proofs/theories/Core.smt2")
+(include "../theories/Core.smt2")
 
 ; Proof rule to test if the parameter `test` evaluates to `reference`
 (declare-rule is_equals ((T Type) (test T) (reference T))
@@ -9,7 +9,7 @@
     :conclusion true
 )
 
-(include "./proofs/programs/Nary.smt2")
+(include "../programs/Nary.smt2")
 
 (declare-const c1 Bool)
 (declare-const c2 Bool)

--- a/proofs/examples/resolution.smt2
+++ b/proofs/examples/resolution.smt2
@@ -1,4 +1,4 @@
-(include "./proofs/rules/Booleans.smt2")
+(include "../rules/Booleans.smt2")
 
 (declare-const c1 Bool)
 (declare-const c2 Bool)

--- a/proofs/examples/simple_uf.smt2
+++ b/proofs/examples/simple_uf.smt2
@@ -1,4 +1,4 @@
-(include "./proofs/rules/Uf.smt2")
+(include "../rules/Uf.smt2")
 
 (declare-type S ())
 (declare-const c1 S)

--- a/proofs/rules/Booleans.smt2
+++ b/proofs/rules/Booleans.smt2
@@ -1,5 +1,5 @@
-(include "./proofs/theories/Core.smt2")
-(include "./proofs/programs/Nary.smt2")
+(include "../theories/Core.smt2")
+(include "../programs/Nary.smt2")
 
 ; SPLIT
 (declare-rule split ((F Bool))

--- a/proofs/rules/Uf.smt2
+++ b/proofs/rules/Uf.smt2
@@ -1,4 +1,4 @@
-(include "./proofs/theories/Core.smt2")
+(include "../theories/Core.smt2")
 
 ; REFL
 (declare-rule refl ((T Type) (t T))

--- a/proofs/theories/BitVectors.smt2
+++ b/proofs/theories/BitVectors.smt2
@@ -1,5 +1,5 @@
 ; Since we don't have full support for scopes, we just import all of Ints for now
-(include "./proofs/theories/Ints.smt2")
+(include "../theories/Ints.smt2")
 
 (declare-type BitVec (Int)) 
 

--- a/proofs/theories/Ints.smt2
+++ b/proofs/theories/Ints.smt2
@@ -1,5 +1,5 @@
-(include "./proofs/theories/Core.smt2")
-(include "./proofs/theories/ArithBridge.smt2")
+(include "../theories/Core.smt2")
+(include "../theories/ArithBridge.smt2")
 
 ; 0, 1, 2, ...
 (declare-consts <numeral> Int) 

--- a/proofs/theories/Reals.smt2
+++ b/proofs/theories/Reals.smt2
@@ -1,5 +1,5 @@
-(include "./proofs/theories/Core.smt2")
-(include "./proofs/theories/ArithBridge.smt2")
+(include "../theories/Core.smt2")
+(include "../theories/ArithBridge.smt2")
 
 (declare-consts <decimal> Real)
 

--- a/src/cmd_parser.cpp
+++ b/src/cmd_parser.cpp
@@ -410,6 +410,7 @@ bool CmdParser::parseNextCommand()
     // (step i F? :rule R :premises (p1 ... pn) :args (t1 ... tm))
     // which is syntax sugar for
     // (define-const i (Proof F) (R t1 ... tm p1 ... pn))
+    // The parameters :premises and :args can be omitted if empty 
     case Token::STEP:
     {
       std::string name = d_eparser.parseSymbol();
@@ -428,20 +429,20 @@ bool CmdParser::parseNextCommand()
       }
       std::string ruleName = d_eparser.parseSymbol();
       Expr rule = d_state.getVar(ruleName);
-      // parse premises
+      // parse premises, optionally
       keyword = d_eparser.parseKeyword();
-      if (keyword!="premises")
+      std::vector<Expr> premises;
+      if (keyword=="premises")
       {
-        d_lex.parseError("Expected premises in step");
+        premises = d_eparser.parseExprList();
+        keyword = d_eparser.parseKeyword();
       }
-      std::vector<Expr> premises = d_eparser.parseExprList();
-      // parse args
-      keyword = d_eparser.parseKeyword();
-      if (keyword!="args")
+      // parse args, optionally
+      std::vector<Expr> args;
+      if (keyword=="args")
       {
-        d_lex.parseError("Expected args in step");
+        args = d_eparser.parseExprList();
       }
-      std::vector<Expr> args = d_eparser.parseExprList();
       std::vector<Expr> children;
       children.push_back(rule);
       // args before premises

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@ int main( int argc, char* argv[] )
 {
   if (argc!=2)
   {
-    std::cerr << "Usage" << std::endl;
+    std::cerr << "Usage: " << argv[0] << " FILE" << std::endl;
     exit(1);
   }
   // include the file

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -49,15 +49,24 @@ void State::popScope()
 
 void State::includeFile(const std::string& s)
 {
-  std::set<std::string>::iterator it = d_includes.find(s);
+  std::filesystem::path inputPath;
+  try {
+    inputPath = std::filesystem::canonical(d_inputFile.parent_path() / s);
+  }
+  catch (std::filesystem::filesystem_error const&)
+  {
+    Error::reportError("State::includeFile: could not include \"" + s + "\"");
+  }
+  std::set<std::filesystem::path>::iterator it = d_includes.find(inputPath);
   if (it!=d_includes.end())
   {
     return;
   }
-  d_includes.insert(s);
-  std::cout << "Include \"" << s << "\"" << std::endl;
+  d_includes.insert(inputPath);
+  d_inputFile = inputPath;
+  std::cout << "Include " << inputPath << std::endl;
   Parser p(*this);
-  p.setFileInput(s);
+  p.setFileInput(inputPath);
   bool parsedCommand;
   do
   {

--- a/src/state.h
+++ b/src/state.h
@@ -4,6 +4,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <filesystem>
 
 #include "expr.h"
 #include "expr_info.h"
@@ -104,8 +105,10 @@ private:
   std::map<Kind, ExprTrie> d_trie;
   /** hash for literals */
   std::map< std::pair<Kind, std::string>, Expr> d_literalTrie;
+  /** input file */
+  std::filesystem::path d_inputFile;
   /** files included */
-  std::set<std::string> d_includes;
+  std::set<std::filesystem::path> d_includes;
   /** Programs */
   std::map<Expr, Expr> d_programs;
   /** Type checker */

--- a/tests/simple-include.smt2
+++ b/tests/simple-include.smt2
@@ -1,5 +1,5 @@
 
-(include "./tests/Bools.smt2")
+(include "./Bools.smt2")
 
 (declare-rule eq-symm ((T Type) (x T) (y T))
   :premises ((= T x y))


### PR DESCRIPTION
`include` is now relative to the current file.  I used the `filesystem` standard library to implement this.  Seems to be more reliable then ad-hoc solutions.

Furthermore, this makes `args` and `premises` optional in `step`, but fixes the order.