### PR TITLE
Refactor and add Boolean Rules

### DIFF
--- a/proofs/examples/booleans.smt2
+++ b/proofs/examples/booleans.smt2
@@ -41,3 +41,7 @@
 (assume reord3 (or c1 c1 (or c1 c2) (not c2) (not c2) c1))
 (step  reordt3 :rule reordering :premises (reord3) :args 
        ((or (or c1 c2) c1 (not c2) c1 (not c2) c1)))
+
+; not_and
+(assume notanda1 (not (and c1 c2 (not c2))))
+(step   notandt1 (or (not c1) (not c2) (not (not c2))) :rule not_and :premises (notanda1))

--- a/proofs/examples/booleans.smt2
+++ b/proofs/examples/booleans.smt2
@@ -48,3 +48,9 @@
 
 ; cnf_and_pos
 (step cnfandpost1 (or (not (and c1 c2 (not c2))) (not c2)) :rule cnf_and_pos :args ((and c1 c2 (not c2)) (not c2) 3))
+
+; cnf_and_neg
+(step cnfandnegt1 (or (and c1 c2 (not c2)) (not c1) (not c2) (not (not c2))) :rule cnf_and_neg :args ((and c1 c2 (not c2))))
+
+; cnf_or_neg
+(step cnfornegt1 (or c1 c2 (not c2) (not (not c2))) :rule cnf_or_neg :args ((or c1 c2 (not c2)) (not c2) 3))

--- a/proofs/examples/booleans.smt2
+++ b/proofs/examples/booleans.smt2
@@ -9,11 +9,21 @@
 (assume a1 (or      c1  c2))
 (assume a2 (or (not c2) c3))
 (assume a3 (not c2))
+(assume a4 (or c1 c2 c3 c2))
 
 (step t1 (or c1 c3) :rule resolution :premises (a1 a2) :args (true c2))
 (step t2 (or c3 c1) :rule resolution :premises (a2 a1) :args (false c2))
 (step t3 c1 :rule resolution :premises (a1 a3) :args (true c2))
 (step t4 c1 :rule resolution :premises (a3 a1) :args (false c2))
+(step t5 (or c1 c3 c2 c3) :rule resolution :premises (a4 a2) :args (true c2))
+(step t6 (or c1 c3 c2) :rule resolution :premises (a4 a3) :args (true c2))
+
+; Chain Resolution
+(assume cra1 (and (or c1 c2 (not c3) c2)
+                  (not c2)
+                  (or c3 c1))
+)
+(step cr1 (or c1 c2 c1) :rule chain_resolution :premises (cra1) :args ((and true c2 false c3)))
 
 ; Factoring
 (assume faca1 (or c1 c1 c2 (not c2) (not c2)))
@@ -31,4 +41,3 @@
 (assume reord3 (or c1 c1 (or c1 c2) (not c2) (not c2) c1))
 (step  reordt3 :rule reordering :premises (reord3) :args 
        ((or (or c1 c2) c1 (not c2) c1 (not c2) c1)))
-

--- a/proofs/examples/booleans.smt2
+++ b/proofs/examples/booleans.smt2
@@ -45,3 +45,6 @@
 ; not_and
 (assume notanda1 (not (and c1 c2 (not c2))))
 (step   notandt1 (or (not c1) (not c2) (not (not c2))) :rule not_and :premises (notanda1))
+
+; cnf_and_pos
+(step cnfandpost1 (or (not (and c1 c2 (not c2))) (not c2)) :rule cnf_and_pos :args ((and c1 c2 (not c2)) (not c2) 3))

--- a/proofs/examples/booleans.smt2
+++ b/proofs/examples/booleans.smt2
@@ -29,7 +29,7 @@
 (assume faca1 (or c1 c1 c2 (not c2) (not c2)))
 (step   fact1 (or c1    c2 (not c2)          ) :rule factoring :premises (faca1))
 (assume faca2 (or c1 (or c1 c1) c2 (not c2) (not c2) c1))
-(step   fact2 (or c1 (or c1 c1) c2 (not c2)          c1) :rule factoring :premises (faca2))
+(step   fact2 (or c1 (or c1 c1) c2 (not c2)            ) :rule factoring :premises (faca2))
 
 ; Reordering
 (assume reord1 (and c1 c2))

--- a/proofs/examples/nary.smt2
+++ b/proofs/examples/nary.smt2
@@ -38,7 +38,6 @@
 (step ap3 :rule check_append :args (c1 nil (remove cons nil c2 (cons c1 c2))))
 
 ; Concat
-
 (declare-rule check_concat((t1 S) (t2 S) (out S))
     :args (t1 t2 out)
     :requires (((concat cons nil t1 t2) out))
@@ -50,7 +49,6 @@
 (step co3 :rule check_concat :args ((cons c1 c2) (cons c1 c3) (cons c1 c2 c1 c3)))
 
 ; Remove
-
 (declare-rule check_remove((c S) (l S) (out S))
     :args (c l out)
     :requires (((remove cons nil c l) out))

--- a/proofs/examples/nary.smt2
+++ b/proofs/examples/nary.smt2
@@ -71,7 +71,7 @@
 )
 
 (step elim1 :rule check_naryElim :args ((cons c1 c2) (cons c1 c2)))
-(step elim2 :rule check_naryElim :args ((remove cons nil c2 (cons c1 c2)) c1))
+(step elim2 :rule check_naryElim :args ((remove cons nil c2 (cons c1 c2))  c1))
 (step elim3 :rule check_naryElim :args ((remove cons nil c2 (cons nil c2)) nil))
 (step elim4 :rule check_naryElim :args ((remove cons nil c2 (cons c2 nil)) nil))
 (step elim5 :rule check_naryElim :args ((remove cons nil c2 (cons (cons c1 c3) c2)) (cons c1 c3)))
@@ -85,3 +85,4 @@
 
 (step intro1 :rule check_naryIntro :args ((cons c1 c2) (cons c1 c2)))
 (step intro3 :rule check_naryIntro :args (c1 (remove cons nil c2 (cons c2 c1))))
+(step intro4 :rule check_naryIntro :args ((cons c1 c2 c3) (cons c1 c2 c3)))

--- a/proofs/examples/nary.smt2
+++ b/proofs/examples/nary.smt2
@@ -1,4 +1,5 @@
 (include "../programs/Nary.smt2")
+(include "../programs/Booleans.smt2")
 
 ; Nary tests on a custom type
 (declare-type S ())

--- a/proofs/examples/nary.smt2
+++ b/proofs/examples/nary.smt2
@@ -11,9 +11,21 @@
 (declare-const c1 S)
 (declare-const c2 S)
 (declare-const c3 S)
+(declare-const c4 S)
+
+; inList
+(declare-rule check_inList((c S) (l S) (out S))
+    :args (c l out)
+    :requires (((inList cons nil c l) out))
+    :conclusion true
+)
+
+(step in1 :rule check_inList :args (c3 (cons c3 c1 c2) true))
+(step in2 :rule check_inList :args (c3 (cons c1 c3 c2) true))
+(step in3 :rule check_inList :args (c3 (cons c1 c2 c3) true))
+(step in4 :rule check_inList :args (c4 (cons c1 c2 c3) false))
 
 ; Append
-
 (declare-rule check_append((c S) (l S) (out S))
     :args (c l out)
     :requires (((append cons c l) out))

--- a/proofs/programs/Booleans.smt2
+++ b/proofs/programs/Booleans.smt2
@@ -3,12 +3,12 @@
 ; inList cons nil c l
 ; Retuns `true` if l inList c.
 (program inList
-    ((U Type) (S Type) (cons (-> S U U)) (nil S) (c S) (x S) (l U :list))
+    ((U Type) (S Type) (cons (-> S U U)) (nil S) (c S) (x S) (xs U :list))
     ((-> S U U) S U S) Bool
     (
-        ((inList cons nil c nil)        false)
-        ((inList cons nil c (cons c l)) true)
-        ((inList cons nil c (cons x l)) (inList cons nil c l))
+        ((inList cons nil c nil)         false)
+        ((inList cons nil c (cons c xs)) true)
+        ((inList cons nil c (cons x xs)) (inList cons nil c xs))
     )
 )
 

--- a/proofs/programs/Booleans.smt2
+++ b/proofs/programs/Booleans.smt2
@@ -1,0 +1,83 @@
+(include "../theories/Core.smt2")
+
+; inList cons nil c l
+; Retuns `true` if l inList c.
+(program inList
+    ((U Type) (S Type) (cons (-> S U U)) (nil S) (c S) (x S) (l U :list))
+    ((-> S U U) S U S) Bool
+    (
+        ((inList cons nil c nil)        false)
+        ((inList cons nil c (cons c l)) true)
+        ((inList cons nil c (cons x l)) (inList cons nil c l))
+    )
+)
+
+; ====================================================================
+;  Specializations the programs to work with n-ary operators for `or`
+; ====================================================================
+
+(program inListOr
+    ((c Bool) (l Bool :list))
+    (Bool Bool) Bool
+    (((inListOr c l) (inList or false c l)))
+)
+(program appendOr
+    ((c Bool) (l Bool :list))
+    (Bool Bool) Bool
+    (((appendOr c l) (append or c l)))
+)
+(program concatOr
+    ((l1 Bool) (l2 Bool))
+    (Bool Bool) Bool
+    (((concatOr l1 l2) (concat or false l1 l2)))
+)
+(program removeOr
+    ((c Bool) (l Bool))
+    (Bool Bool) Bool
+    (((removeOr c l) (remove or false c l)))
+)
+(program naryElimOr
+    ((t Bool))
+    (Bool) Bool
+    (((naryElimOr t) (naryElim or false t)))
+)
+(program naryIntroOr
+    ((t Bool))
+    (Bool) Bool
+    (((naryIntroOr t) (naryIntro or false t)))
+)
+
+; ==================================================================
+;  Specializations the programs to work with n-ary operators for `or`
+; ==================================================================
+
+(program inListAnd
+    ((c Bool) (l Bool :list))
+    (Bool Bool) Bool
+    (((inListAnd c l) (inList and true c l)))
+)
+(program appendAnd
+    ((c Bool) (l Bool :list))
+    (Bool Bool) Bool
+    (((appendAnd c l) (append and c l)))
+)
+(program concatAnd
+    ((l1 Bool) (l2 Bool))
+    (Bool Bool) Bool
+    (((concatAnd l1 l2) (concat and true l1 l2)))
+)
+(program removeAnd
+    ((c Bool) (l Bool))
+    (Bool Bool) Bool
+    (((removeAnd c l) (remove and true c l)))
+)
+(program naryElimAnd
+    ((t Bool))
+    (Bool) Bool
+    (((naryElimAnd t) (naryElim and true t)))
+)
+(program naryIntroAnd
+    ((t Bool))
+    (Bool) Bool
+    (((naryIntroAnd t) (naryIntro and true t)))
+)

--- a/proofs/programs/Booleans.smt2
+++ b/proofs/programs/Booleans.smt2
@@ -1,5 +1,16 @@
 (include "../theories/Core.smt2")
 
+; ifThenElse b t1 t2
+; Returns `t1` if `b` is `true`. If it is `false` it returns `t2`.
+(program ifThenElse
+    ((S Type) (b Bool) (t1 S) (t2 S))
+    (Bool S S) S
+    (
+        ((ifThenElse true  t1 t2) t1)
+        ((ifThenElse false t1 t2) t2)
+    )
+)
+
 ; inList cons nil c l
 ; Retuns `true` if l inList c.
 (program inList
@@ -36,6 +47,13 @@
     (Bool Bool) Bool
     (((removeOr c l) (remove or false c l)))
 )
+(program reverseOr
+    ((xs Bool :list))
+    (Bool) Bool
+    (
+        ((reverseOr xs) (reverse or false xs))
+    )
+)
 (program naryElimOr
     ((t Bool))
     (Bool) Bool
@@ -70,6 +88,13 @@
     ((c Bool) (l Bool))
     (Bool Bool) Bool
     (((removeAnd c l) (remove and true c l)))
+)
+(program reverseAnd
+    ((xs Bool :list))
+    (Bool) Bool
+    (
+        ((reverseAnd xs) (reverse and true xs))
+    )
 )
 (program naryElimAnd
     ((t Bool))

--- a/proofs/programs/Nary.smt2
+++ b/proofs/programs/Nary.smt2
@@ -24,78 +24,78 @@
 ; A call `(append x xs)` will create the list from point 1 and `(append x nil)`
 ; will create a unit list.
 
-; append cons nil c l
-; Appends c to the head of l.
+; append cons nil c xs
+; Appends `c` to the head of `xs`.
 (program append
-    ((U Type) (S Type) (cons (-> S U U)) (c S) (l U :list))
-    ((-> S U U) S U) U
+    ((L Type) (E Type) (cons (-> E L L)) (c E) (xs L :list))
+    ((-> E L L) E L) L
     (
-        ((append cons c l) (cons c l))
+        ((append cons c xs) (cons c xs))
     )
 )
 
-; concat cons nil l1 l2
-; Concatenates two lists l1 and l2.
+; concat cons nil xs ys
+; Concatenates two lists `xs` and `ys`.
 (program concat
-    ((U Type) (S Type) (cons (-> S U U)) (nil S) (l1 U) (l1s U :list) (l2 U))
-    ((-> S U U) S U U) U
+    ((L Type) (E Type) (cons (-> E L L)) (nil L) (x L) (xs L :list) (ys L))
+    ((-> E L L) E L L) L
     (
-        ((concat cons nil nil l2) l2)
-        ((concat cons nil (cons l1 l1s) l2) (append cons l1 (concat cons nil l1s l2)))
+        ((concat cons nil nil ys) ys)
+        ((concat cons nil (cons x xs) ys) (append cons x (concat cons nil xs ys)))
     )
 )
 
-; remove cons nil c l
-; Removes the first occurrence of c from l.
+; remove cons nil c xs
+; Removes the first occurrence of `c` from `xs`.
 (program remove
-    ((U Type) (S Type) (cons (-> S U U)) (nil S) (c S) (cp S) (l U :list))
-    ((-> S U U) S S U) U
+    ((L Type) (E Type) (cons (-> E L L)) (nil L) (c E) (y E) (xs L :list))
+    ((-> E L L) E E L) L
     (
         ((remove cons nil c nil) nil)
-        ((remove cons nil c (cons c l)) l)
-        ((remove cons nil c (cons cp l)) (append cons cp (remove cons nil c l)))
+        ((remove cons nil c (cons c xs)) xs)
+        ((remove cons nil c (cons y xs)) (append cons y (remove cons nil c xs)))
     )
 )
 
 ; Helper for reverse
 (program reverseRec
-    ((U Type) (S Type) (cons (-> S U U)) (nil U) (x U) (xs U :list) (l U :list))
-    ((-> S U U) U U U) U
+    ((L Type) (E Type) (cons (-> E L L)) (nil L) (x L) (xs L :list) (l L :list))
+    ((-> E L L) L L L) L
     (
-        ((reverseRec cons nil nil l)         l)
+        ((reverseRec cons nil nil         l)  l)
         ((reverseRec cons nil (cons x xs) l) (reverseRec cons nil xs (append cons x l)))
     )
 )
 
-; reverse cons nil l
-; Reverses the list `l`.
+; reverse cons nil xs
+; Reverses the list `xs`.
 (program reverse
-    ((U Type) (S Type) (cons (-> S U U)) (nil U) (xs U :list))
-    ((-> S U U) U U) U
+    ((L Type) (E Type) (cons (-> E L L)) (nil L) (xs L :list))
+    ((-> E L L) L L) L
     (
         ((reverse cons nil xs) (reverseRec cons nil xs nil))
     )
 )
 
 
-; naryElim cons nil l
-; Returns the sole element if l is a singleton list.
+; naryElim cons nil x
+; Returns the sole element if `xs` is a singleton list.
 (program naryElim
-    ((U Type) (S Type) (cons (-> U U U)) (nil U) (l U) (ls U :list))
-    ((-> U U U) U U) U
+    ((L Type) (cons (-> L L L)) (nil L) (x L) (xs L :list))
+    ((-> L L L) L L) L
     (
-        ((naryElim cons nil (cons l ls)) (ifEqThenElse ls nil l (cons l ls)))
-        ((naryElim cons nil l) l)
+        ((naryElim cons nil (cons x xs)) (ifEqThenElse xs nil x (append cons x xs)))
+        ((naryElim cons nil xs) xs)
     )
 )
 
-; naryIntro cons nil l
-; Returns a singleton list if c is not a list.
+; naryIntro cons nil x
+; Returns a singleton list if `x` is not a list.
 (program naryIntro
-    ((U Type) (S Type) (cons (-> U U U)) (nil U) (c U) (l U :list))
-    ((-> U U U) U U) U
+    ((L Type) (cons (-> L L L)) (nil L) (x L) (xs L :list))
+    ((-> L L L) L L) L
     (
-        ((naryIntro cons nil (cons c l)) (cons c l))
-        ((naryIntro cons nil c) (append cons c nil))
+        ((naryIntro cons nil (cons x xs)) (append cons x xs))
+        ((naryIntro cons nil x)           (append cons x nil))
     )
 )

--- a/proofs/programs/Nary.smt2
+++ b/proofs/programs/Nary.smt2
@@ -57,6 +57,27 @@
     )
 )
 
+; Helper for reverse
+(program reverseRec
+    ((U Type) (S Type) (cons (-> S U U)) (nil U) (x U) (xs U :list) (l U :list))
+    ((-> S U U) U U U) U
+    (
+        ((reverseRec cons nil nil l)         l)
+        ((reverseRec cons nil (cons x xs) l) (reverseRec cons nil xs (append cons x l)))
+    )
+)
+
+; reverse cons nil l
+; Reverses the list `l`.
+(program reverse
+    ((U Type) (S Type) (cons (-> S U U)) (nil U) (xs U :list))
+    ((-> S U U) U U) U
+    (
+        ((reverse cons nil xs) (reverseRec cons nil xs nil))
+    )
+)
+
+
 ; naryElim cons nil l
 ; Returns the sole element if l is a singleton list.
 (program naryElim

--- a/proofs/programs/Nary.smt2
+++ b/proofs/programs/Nary.smt2
@@ -1,46 +1,31 @@
 ; Programs to work with n-ary operators
 
-(include "../theories/Core.smt2")
+(include "../programs/Utils.smt2")
 
 ; =============================================
 ;  Right-associative null-terminated operators
 ; =============================================
-
-; =====================
-;   Generic List Type
-; =====================
-
-; Nary tests on a custom type
-;(declare-type List (Type))
-;(declare-const nil (-> (! Type :var E) (List E)))
-;(declare-const cons (-> (! Type :var E :implicit) E (List E) (List E))
-;    :right-assoc nil
-;)
-
-
 ; The following functions work with right-associative symbols with a defined
 ; null terminator.  Those behave somewhat similar to functional programming
 ; lists.  Therefore, the symbol will always be called `cons` in the following
 ; and the terminator will be `nil`.
-; One derivation from lists is that the syntactic sugar cannot be used to
-; write unit lists. For example, consider a right-associative `or` with
-; `false` as the terminator, then `(or a b c)` corresponds to
-; `(or a (or b (or c false)))`, but `(or a)` is illegal.
-
-; inList cons nil c l
-; Retuns `true` if l inList c.
-(program inList
-    ((U Type) (S Type) (cons (-> S U U)) (nil S) (c S) (x S) (l U :list))
-    ((-> S U U) S U S) Bool
-    (
-        ((inList cons nil c nil)        false)
-        ((inList cons nil c (cons c l)) true)
-        ((inList cons nil c (cons x l)) (inList cons nil c l))
-    )
-)
+;
+; The AletheLF syntactic sugar for n-ary operators introduces some behavior
+; that can be counter intuitive:
+; 1) Consider a pattern `(cons x xs)` where `xs` is annotated with `:list`.
+;    In this case building the term `(cons x xs)` will not result in the
+;    term that matched the pattern.  This is because `(cons x xs)` is
+;    syntactic sugar for `(cons x (cons xs nil))`.  Note that, xs here
+;    is not the tail of the list.  It is just an element.
+; 2) It is not possible to directly build unit lists, since `(cons x)` is
+;    not valid.
+;
+; Both cases can be addressed by using the `append` function defined below.
+; A call `(append x xs)` will create the list from point 1 and `(append x nil)`
+; will create a unit list.
 
 ; append cons nil c l
-; Apppends c to the head of l.
+; Appends c to the head of l.
 (program append
     ((U Type) (S Type) (cons (-> S U U)) (c S) (l U :list))
     ((-> S U U) S U) U
@@ -61,7 +46,7 @@
 )
 
 ; remove cons nil c l
-; Removes the first occurence of c from l.
+; Removes the first occurrence of c from l.
 (program remove
     ((U Type) (S Type) (cons (-> S U U)) (nil S) (c S) (cp S) (l U :list))
     ((-> S U U) S S U) U
@@ -72,18 +57,8 @@
     )
 )
 
-; TODO: move to other header with general helpers
-(program ifEqThenElse
-    ((U Type) (S Type) (x U) (cmp U) (t1 S) (t2 S))
-    (U U S S) S
-    (
-        ((ifEqThenElse x   x t1 t2) t1)
-        ((ifEqThenElse x cmp t1 t2) t2)
-    )
-)
-
 ; naryElim cons nil l
-; Returns the sole elment if l is a singleton list.
+; Returns the sole element if l is a singleton list.
 (program naryElim
     ((U Type) (S Type) (cons (-> U U U)) (nil U) (l U) (ls U :list))
     ((-> U U U) U U) U
@@ -102,74 +77,4 @@
         ((naryIntro cons nil (cons c l)) (cons c l))
         ((naryIntro cons nil c) (append cons c nil))
     )
-)
-
-; ==================================================================
-;        Specializations of the functions above for `or`
-; ==================================================================
-
-(program inListOr
-    ((c Bool) (l Bool :list))
-    (Bool Bool) Bool
-    (((inListOr c l) (inList or false c l)))
-)
-(program appendOr
-    ((c Bool) (l Bool :list))
-    (Bool Bool) Bool
-    (((appendOr c l) (append or c l)))
-)
-(program concatOr
-    ((l1 Bool) (l2 Bool))
-    (Bool Bool) Bool
-    (((concatOr l1 l2) (concat or false l1 l2)))
-)
-(program removeOr
-    ((c Bool) (l Bool))
-    (Bool Bool) Bool
-    (((removeOr c l) (remove or false c l)))
-)
-(program naryElimOr
-    ((t Bool))
-    (Bool) Bool
-    (((naryElimOr t) (naryElim or false t)))
-)
-(program naryIntroOr
-    ((t Bool))
-    (Bool) Bool
-    (((naryIntroOr t) (naryIntro or false t)))
-)
-
-; ==================================================================
-;        Specializations of the functions above for `and`
-; ==================================================================
-
-(program inListAnd
-    ((c Bool) (l Bool :list))
-    (Bool Bool) Bool
-    (((inListAnd c l) (inList and true c l)))
-)
-(program appendAnd
-    ((c Bool) (l Bool :list))
-    (Bool Bool) Bool
-    (((appendAnd c l) (append and c l)))
-)
-(program concatAnd
-    ((l1 Bool) (l2 Bool))
-    (Bool Bool) Bool
-    (((concatAnd l1 l2) (concat and true l1 l2)))
-)
-(program removeAnd
-    ((c Bool) (l Bool))
-    (Bool Bool) Bool
-    (((removeAnd c l) (remove and true c l)))
-)
-(program naryElimAnd
-    ((t Bool))
-    (Bool) Bool
-    (((naryElimAnd t) (naryElim and true t)))
-)
-(program naryIntroAnd
-    ((t Bool))
-    (Bool) Bool
-    (((naryIntroAnd t) (naryIntro and true t)))
 )

--- a/proofs/programs/Nary.smt2
+++ b/proofs/programs/Nary.smt2
@@ -2,9 +2,21 @@
 
 (include "../theories/Core.smt2")
 
-; ====================================
-;  Right-associative null-terminated
-; ====================================
+; =============================================
+;  Right-associative null-terminated operators
+; =============================================
+
+; =====================
+;   Generic List Type
+; =====================
+
+; Nary tests on a custom type
+;(declare-type List (Type))
+;(declare-const nil (-> (! Type :var E) (List E)))
+;(declare-const cons (-> (! Type :var E :implicit) E (List E) (List E))
+;    :right-assoc nil
+;)
+
 
 ; The following functions work with right-associative symbols with a defined
 ; null terminator.  Those behave somewhat similar to functional programming
@@ -15,7 +27,20 @@
 ; `false` as the terminator, then `(or a b c)` corresponds to
 ; `(or a (or b (or c false)))`, but `(or a)` is illegal.
 
-; append c to the head of l
+; inList cons nil c l
+; Retuns `true` if l inList c.
+(program inList
+    ((U Type) (S Type) (cons (-> S U U)) (nil S) (c S) (x S) (l U :list))
+    ((-> S U U) S U S) Bool
+    (
+        ((inList cons nil c nil)        false)
+        ((inList cons nil c (cons c l)) true)
+        ((inList cons nil c (cons x l)) (inList cons nil c l))
+    )
+)
+
+; append cons nil c l
+; Apppends c to the head of l.
 (program append
     ((U Type) (S Type) (cons (-> S U U)) (c S) (l U :list))
     ((-> S U U) S U) U
@@ -24,7 +49,8 @@
     )
 )
 
-; concatenate two lists l1, l2
+; concat cons nil l1 l2
+; Concatenates two lists l1 and l2.
 (program concat
     ((U Type) (S Type) (cons (-> S U U)) (nil S) (l1 U) (l1s U :list) (l2 U))
     ((-> S U U) S U U) U
@@ -34,7 +60,8 @@
     )
 )
 
-; remove the first occurence of c from l
+; remove cons nil c l
+; Removes the first occurence of c from l.
 (program remove
     ((U Type) (S Type) (cons (-> S U U)) (nil S) (c S) (cp S) (l U :list))
     ((-> S U U) S S U) U
@@ -55,7 +82,8 @@
     )
 )
 
-; returns the sole elment if l is singleton list
+; naryElim cons nil l
+; Returns the sole elment if l is a singleton list.
 (program naryElim
     ((U Type) (S Type) (cons (-> U U U)) (nil U) (l U) (ls U :list))
     ((-> U U U) U U) U
@@ -65,7 +93,8 @@
     )
 )
 
-; returns a singleton list if the argument is not
+; naryIntro cons nil l
+; Returns a singleton list if c is not a list.
 (program naryIntro
     ((U Type) (S Type) (cons (-> U U U)) (nil U) (c U) (l U :list))
     ((-> U U U) U U) U
@@ -79,6 +108,11 @@
 ;        Specializations of the functions above for `or`
 ; ==================================================================
 
+(program inListOr
+    ((c Bool) (l Bool :list))
+    (Bool Bool) Bool
+    (((inListOr c l) (inList or false c l)))
+)
 (program appendOr
     ((c Bool) (l Bool :list))
     (Bool Bool) Bool
@@ -109,6 +143,11 @@
 ;        Specializations of the functions above for `and`
 ; ==================================================================
 
+(program inListAnd
+    ((c Bool) (l Bool :list))
+    (Bool Bool) Bool
+    (((inListAnd c l) (inList and true c l)))
+)
 (program appendAnd
     ((c Bool) (l Bool :list))
     (Bool Bool) Bool

--- a/proofs/programs/Utils.smt2
+++ b/proofs/programs/Utils.smt2
@@ -1,4 +1,3 @@
-
 ; ifEqThenElse x y t1 t2
 ; Returns `t1` if `x` and `y` are the same term.  Otherwise, returns `t2`.
 (program ifEqThenElse

--- a/proofs/programs/Utils.smt2
+++ b/proofs/programs/Utils.smt2
@@ -1,0 +1,11 @@
+
+; ifEqThenElse x y t1 t2
+; Returns `t1` if `x` and `y` are the same term.  Otherwise, returns `t2`.
+(program ifEqThenElse
+    ((U Type) (S Type) (x U) (cmp U) (t1 S) (t2 S))
+    (U U S S) S
+    (
+        ((ifEqThenElse x   x t1 t2) t1)
+        ((ifEqThenElse x cmp t1 t2) t2)
+    )
+)

--- a/proofs/rules/Booleans.smt2
+++ b/proofs/rules/Booleans.smt2
@@ -1,6 +1,9 @@
 (include "../theories/Core.smt2")
 (include "../theories/Ints.smt2")
+
 (include "../programs/Nary.smt2")
+(include "../programs/Booleans.smt2")
+
 
 ; SPLIT
 (declare-rule split ((F Bool))

--- a/proofs/rules/Booleans.smt2
+++ b/proofs/rules/Booleans.smt2
@@ -85,19 +85,18 @@
 )
 
 ; FACTORING
-(program factorLiterals ((l Bool) (ls Bool :list))
-    (Bool) Bool
+(program factorLiterals ((xs Bool :list) (l Bool) (ls Bool :list))
+    (Bool Bool) Bool
     (
-        ((factorLiterals false) false)
-        ((factorLiterals (or l l ls)) (factorLiterals (appendOr l ls)))
-        ((factorLiterals (or l ls))   (appendOr l (factorLiterals ls)))
-        ((factorLiterals ls) ls)
+        ((factorLiterals xs false) xs)
+        ((factorLiterals xs (or l ls)) (ifThenElse (inListOr l xs) (factorLiterals xs              ls)
+                                                                   (factorLiterals (appendOr l xs) ls)))
     )
 )
 
 (declare-rule factoring ((C Bool))
     :premises (C)
-    :conclusion (factorLiterals C)
+    :conclusion (reverseOr (factorLiterals false C))
 )
 
 ; REORDERING

--- a/proofs/rules/Booleans.smt2
+++ b/proofs/rules/Booleans.smt2
@@ -188,8 +188,7 @@
 
 ; NOT_IMPLIES_ELIM1
 (declare-rule not_implies_elim1 ((F1 Bool) (F2 Bool))
-    :premises ((not (=> F1 F2)))
-    :conclusion F1
+    :premises ((not (=> F1 F2)))    :conclusion F1
 )
 
 ; NOT_IMPLIES_ELIM2
@@ -285,6 +284,14 @@
 )
 
 ; CNF_AND_POS
+; TODO: Fi should not be explicit, but the ith conjunct from Fs.  Since we do
+; not yet have integer arithmetic, we cannot implment this yet.
+(declare-rule cnf_and_pos ((Fs Bool) (Fi Bool) (i Int))
+    :args (Fs Fi i)
+    :requires (((inListAnd Fi Fs) true))
+    :conclusion (or (not Fs) Fi)
+)
+
 ; CNF_AND_NEG
 ; CNF_OR_POS
 ; CNF_OR_NEG

--- a/proofs/rules/Booleans.smt2
+++ b/proofs/rules/Booleans.smt2
@@ -270,17 +270,21 @@
 )
 
 ; NOT_AND
-(program lowerNot ((l Bool) (ls Bool :list))
+
+; lowerNotAnd c
+; Moves a negation into a disjunction.
+; `lowerNotAnd (and l1 .. ln) = (or (not l1) ... (not ln))`
+(program lowerNotAnd ((l Bool) (ls Bool :list))
     (Bool) Bool
     (
-        ((lowerNot true) false) ; Terminator changes
-        ((lowerNot (and l ls)) (appendOr (not l) (lowerNot ls)))
+        ((lowerNotAnd true) false) ; Terminator changes
+        ((lowerNotAnd (and l ls)) (appendOr (not l) (lowerNotAnd ls)))
     )
 )
 
 (declare-rule not_and ((F Bool))
     :premises ((not F))
-    :conclusion (lowerNot F)
+    :conclusion (lowerNotAnd F)
 )
 
 ; CNF_AND_POS
@@ -293,23 +297,131 @@
 )
 
 ; CNF_AND_NEG
+(declare-rule cnf_and_neg ((Fs Bool))
+    :args (Fs)
+    :conclusion (appendOr Fs (lowerNotAnd Fs))
+)
+
 ; CNF_OR_POS
+(declare-rule cnf_or_pos ((Fs Bool))
+    :args (Fs)
+    :conclusion (appendOr (not Fs) Fs)
+)
+
 ; CNF_OR_NEG
+; TODO: Fi should not be explicit, but the ith conjunct from Fs.  Since we do
+; not yet have integer arithmetic, we cannot implment this yet.
+(declare-rule cnf_or_neg ((Fs Bool) (Fi Bool) (i Int))
+    :args (Fs Fi i)
+    :requires (((inListOr Fi Fs) true))
+    :conclusion (concatOr Fs (appendOr (not Fi) false))
+)
+
 ; CNF_IMPLIES_POS
+(declare-rule cnf_implies_pos ((F1 Bool) (F2 Bool))
+    :args ((=> F1 F2))
+    :conclusion (or (not (=> F1 F2)) (not F1) F2)
+)
+
 ; CNF_IMPLIES_NEG1
+(declare-rule cnf_implies_neg1 ((F1 Bool) (F2 Bool))
+    :args ((=> F1 F2))
+    :conclusion (or (=> F1 F2) F1)
+)
+
 ; CNF_IMPLIES_NEG2
+(declare-rule cnf_implies_neg2 ((F1 Bool) (F2 Bool))
+    :args ((=> F1 F2))
+    :conclusion (or (=> F1 F2) (not F2))
+)
+
 ; CNF_EQUIV_POS1
+(declare-rule cnf_equiv_pos1 ((F1 Bool) (F2 Bool))
+    :args ((= F1 F2))
+    :conclusion (or (not (= F1 F2)) (not F1) F2)
+)
+
 ; CNF_EQUIV_POS2
+(declare-rule cnf_equiv_pos2 ((F1 Bool) (F2 Bool))
+    :args ((= F1 F2))
+    :conclusion (or (not (= F1 F2)) F1 (not F2))
+)
+
 ; CNF_EQUIV_NEG1
+(declare-rule cnf_equiv_neg1 ((F1 Bool) (F2 Bool))
+    :args ((= F1 F2))
+    :conclusion (or (= F1 F2) F1 F2)
+)
+
 ; CNF_EQUIV_NEG2
+(declare-rule cnf_equiv_neg2 ((F1 Bool) (F2 Bool))
+    :args ((= F1 F2))
+    :conclusion (or (= F1 F2) (not F1) (not F2))
+)
+
 ; CNF_XOR_POS1
+(declare-rule cnf_xor_pos1 ((F1 Bool) (F2 Bool))
+    :args ((xor F1 F2))
+    :conclusion (or (not (xor F1 F2)) F1 F2)
+)
+
 ; CNF_XOR_POS2
+(declare-rule cnf_xor_pos2 ((F1 Bool) (F2 Bool))
+    :args ((xor F1 F2))
+    :conclusion (or (not (xor F1 F2)) (not F1) (not F2))
+)
+
 ; CNF_XOR_NEG1
+(declare-rule cnf_xor_neg1 ((F1 Bool) (F2 Bool))
+    :args ((xor F1 F2))
+    :conclusion (or (xor F1 F2) (not F1) F2)
+)
+
 ; CNF_XOR_NEG2
+(declare-rule cnf_xor_neg2 ((F1 Bool) (F2 Bool))
+    :args ((xor F1 F2))
+    :conclusion (or (xor F1 F2) F1 (not F2))
+)
+
 ; CNF_ITE_POS1
+(declare-rule cnf_ite_pos1 ((C Bool) (F1 Bool) (F2 Bool))
+    :args ((ite C F1 F2))
+    :conclusion (or (not (ite C F1 F2)) (not C) F1)
+)
+
 ; CNF_ITE_POS2
+(declare-rule cnf_ite_pos2 ((C Bool) (F1 Bool) (F2 Bool))
+    :args ((ite C F1 F2))
+    :conclusion (or (not (ite C F1 F2)) C F2)
+)
+
 ; CNF_ITE_POS3
+(declare-rule cnf_ite_pos3 ((C Bool) (F1 Bool) (F2 Bool))
+    :args ((ite C F1 F2))
+    :conclusion (or (not (ite C F1 F2)) F1 F2)
+)
+
 ; CNF_ITE_NEG1
+(declare-rule cnf_ite_neg1 ((C Bool) (F1 Bool) (F2 Bool))
+    :args ((ite C F1 F2))
+    :conclusion (or (ite C F1 F2) (not C) (not F1))
+)
+
 ; CNF_ITE_NEG2
+(declare-rule cnf_ite_neg2 ((C Bool) (F1 Bool) (F2 Bool))
+    :args ((ite C F1 F2))
+    :conclusion (or (ite C F1 F2) C (not F2))
+)
+
 ; CNF_ITE_NEG3
+(declare-rule cnf_ite_neg3 ((C Bool) (F1 Bool) (F2 Bool))
+    :args ((ite C F1 F2))
+    :conclusion (or (ite C F1 F2) (not F1) (not F2))
+)
+
 ; SAT_REFUTATION
+; trust rule
+(declare-rule sat_refutation ((Fs Bool))
+    :premises (Fs)
+    :conclusion false
+)

--- a/proofs/rules/Booleans.smt2
+++ b/proofs/rules/Booleans.smt2
@@ -36,8 +36,34 @@
     :conclusion (resolve C1 C2 pol L)
 )
 
-; TODO: needs support for premise lists
 ; CHAIN_RESOLUTION
+(program chainResolveRec((C1 Bool) (C2 Bool) (Cs Bool :list) (pol Bool) (L Bool) (args Bool :list))
+    (Bool Bool Bool) Bool
+    (
+        ((chainResolveRec C1 true true) C1)
+        ((chainResolveRec C1 (and C2 Cs) (and pol L args)) (chainResolveRec (resolve C1 C2 pol L) Cs args))
+    )
+)
+
+(program chainResolve((C1 Bool) (Cs Bool :list) (args Bool))
+    (Bool Bool) Bool
+    (
+        ((chainResolve (and C1 Cs) args) (chainResolveRec C1 Cs args))
+    )
+)
+
+; This is a chain or resolution steps as described in the cvc5 proof rule
+; documentation.
+; `Cs` is a conjunction or the premise clauses.  This can be built by using
+;      multiple `and_intro` steps.
+; `args` is a conjunction where the alternating conjuncts are polarity and
+;        pivot literal.
+(declare-rule chain_resolution ((Cs Bool) (args Bool))
+    :premises (Cs)
+    :args (args)
+    :conclusion (chainResolve Cs args)
+)
+
 ; MACRO_RESOLUTION_TRUST
 ; MACRO_RESOLUTION
 

--- a/proofs/rules/Uf.smt2
+++ b/proofs/rules/Uf.smt2
@@ -9,22 +9,22 @@
 
 ; SYMM
 ; Either t1 = t2 ==> t2 = t1 or t1 != t2 ==> t2 != t1
-(program flip_eq ((T Type) (t1 T) (t2 T))
+(program flipEq ((T Type) (t1 T) (t2 T))
     (Bool) Bool
     (
-        ((flip_eq (= t1 t2)) (= t2 t1))
-        ((flip_eq (not (= t1 t2))) (not (= t2 t1)))
+        ((flipEq (= t1 t2)) (= t2 t1))
+        ((flipEq (not (= t1 t2))) (not (= t2 t1)))
     )
 )
 
 (declare-rule symm ((F Bool))
     :premises (F)
     :args ()
-    :conclusion (flip_eq F)
+    :conclusion (flipEq F)
 )
 
 ; TRANS
-; Only binary for now, because we don't have lists
+; Only binary trans supported
 (declare-rule trans ((T Type) (t1 T) (t2 T) (t3 T))
     :premises ((= t1 t2) (= t2 t3))
     :args ()
@@ -32,8 +32,7 @@
 )
 
 ; CONG
-; Only unary for now, because we don't have lists
-; and no support for different kinds.
+; Only binary cong supported
 (declare-rule cong ((T Type) (U Type) (f (-> T U)) (t1 T) (t2 T))
     :premises ((= t1 t2))
     :args (f)
@@ -69,7 +68,7 @@
 )
 
 ; HO_CONG
-; Only unary for now, because we don't have lists
+; Only binary ho_cong supported
 (declare-rule ho_cong ((T Type) (U Type) (f (-> T U)) (g (-> T U)) (t1 T) (t2 T))
     :premises ((= f g) (= t1 t2))
     :args ()

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -130,6 +130,7 @@ void State::includeFileInternal(const std::string& s, bool ignore)
     return;
   }
   d_includes.insert(inputPath);
+  std::filesystem::path currentPath = d_inputFile;
   d_inputFile = inputPath;
   if (d_compiler!=nullptr)
   {
@@ -148,6 +149,7 @@ void State::includeFileInternal(const std::string& s, bool ignore)
     parsedCommand = p.parseNextCommand();
   }
   while (parsedCommand);
+  d_inputFile = currentPath;
   std::cout << "...finished" << std::endl;
 }
 

--- a/tests/not_and.smt2
+++ b/tests/not_and.smt2
@@ -1,4 +1,6 @@
+(include "../proofs/theories/Core.smt2")
 (include "../proofs/programs/Nary.smt2")
+(include "../proofs/programs/Booleans.smt2")
 
 ; NOT_AND
 (program lowerNot ((l Bool) (ls Bool :list))


### PR DESCRIPTION
This adds the remaining boolean rules and splits the programs into programs just for lists, and programs for Boolean lists.

There is also one tiny bugfix to the `include` mechanism in `alfc`.  It did not correctly return to the base file after an include.  That is
```
(include "a/b.smt2")
(include "c/d.smt2")
```
would fail, because it `alftc` would attempt to include `a/c/d.smt2`.