### PR TITLE
Include cstdint to fix compilation on gcc 13

### DIFF
--- a/src/integer.h
+++ b/src/integer.h
@@ -5,6 +5,7 @@
 
 #include <iosfwd>
 #include <string>
+#include <cstdint>
 
 namespace alfc {
 


### PR DESCRIPTION
See: https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes