### PR TITLE
Fix resolution to false.

### DIFF
--- a/proofs/examples/booleans.smt2
+++ b/proofs/examples/booleans.smt2
@@ -10,6 +10,7 @@
 (assume a2 (or (not c2) c3))
 (assume a3 (not c2))
 (assume a4 (or c1 c2 c3 c2))
+(assume a5 c2)
 
 (step t1 (or c1 c3) :rule resolution :premises (a1 a2) :args (true c2))
 (step t2 (or c3 c1) :rule resolution :premises (a2 a1) :args (false c2))
@@ -17,6 +18,7 @@
 (step t4 c1 :rule resolution :premises (a3 a1) :args (false c2))
 (step t5 (or c1 c3 c2 c3) :rule resolution :premises (a4 a2) :args (true c2))
 (step t6 (or c1 c3 c2) :rule resolution :premises (a4 a3) :args (true c2))
+(step t7 false :rule resolution :premises (a3 a5) :args (false c2))
 
 ; Chain Resolution
 (assume cra1 (and (or c1 c2 (not c3) c2)
@@ -24,6 +26,13 @@
                   (or c3 c1))
 )
 (step cr1 (or c1 c2 c1) :rule chain_resolution :premises (cra1) :args ((and true c2 false c3)))
+
+(assume cra2 (and (or c1 c2 )
+                  (not c1)
+                  (not c2))
+)
+(step cr2 false :rule chain_resolution :premises (cra2) :args ((and true c1 true c2)))
+; TODO: case where only one is left
 
 ; Factoring
 (assume faca1 (or c1 c1 c2 (not c2) (not c2)))

--- a/proofs/examples/nary.smt2
+++ b/proofs/examples/nary.smt2
@@ -63,16 +63,19 @@
 (step rm7 :rule check_remove :args (c2 (cons c1 c2 c2 c3) (cons c1 c2 c3)))
 
 ; naryElim
+
+; Constant to map the nil constant to in empty lists
+(declare-const elim-nil S)
 (declare-rule check_naryElim((in S) (out S))
     :args (in out)
-    :requires (((naryElim cons (alf.nil S) in) out))
+    :requires (((naryElim cons (alf.nil S) elim-nil in) out))
     :conclusion true
 )
 
 (step elim1 :rule check_naryElim :args ((cons c1 c2) (cons c1 c2)))
 (step elim2 :rule check_naryElim :args ((remove cons c2 (cons c1 c2))  c1))
 (step elim3 :rule check_naryElim :args ((remove cons c2 (cons (alf.nil S) c2)) (alf.nil S)))
-(step elim4 :rule check_naryElim :args ((remove cons c2 (cons c2 (alf.nil S))) (alf.nil S)))
+(step elim4 :rule check_naryElim :args ((remove cons c1 (remove cons c2 (cons c1 c2))) elim-nil))
 (step elim5 :rule check_naryElim :args ((remove cons c2 (cons (cons c1 c3) c2)) (cons c1 c3)))
 
 ; naryIntro

--- a/proofs/programs/Booleans.smt2
+++ b/proofs/programs/Booleans.smt2
@@ -57,7 +57,7 @@
 (program naryElimOr
     ((t Bool))
     (Bool) Bool
-    (((naryElimOr t) (naryElim or (alf.nil Bool) t)))
+    (((naryElimOr t) (naryElim or (alf.nil Bool) false t)))
 )
 (program naryIntroOr
     ((t Bool))
@@ -99,7 +99,7 @@
 (program naryElimAnd
     ((t Bool))
     (Bool) Bool
-    (((naryElimAnd t) (naryElim and (alf.nil Bool) t)))
+    (((naryElimAnd t) (naryElim and (alf.nil Bool) true t)))
 )
 (program naryIntroAnd
     ((t Bool))

--- a/proofs/programs/Nary.smt2
+++ b/proofs/programs/Nary.smt2
@@ -80,12 +80,13 @@
 ; naryElim cons x
 ; Returns the sole element if `xs` is a singleton list.
 (program naryElim
-    ((L Type) (cons (-> L L L)) (nil L) (x L) (xs L :list))
-    ((-> L L L) L L) L
+    ((L Type) (cons (-> L L L)) (nil L) (c L) (x L) (xs L :list))
+    ((-> L L L) L L L) L
     (
-        ((naryElim cons nil (cons x nil)) x)
-        ((naryElim cons nil (cons x xs)) (append cons x xs))
-        ((naryElim cons nil xs) xs)
+        ((naryElim cons nil c nil) c)
+        ((naryElim cons nil c (cons x nil)) x)
+        ((naryElim cons nil c (cons x xs)) (append cons x xs))
+        ((naryElim cons nil c xs) xs)
     )
 )
 


### PR DESCRIPTION
This broke with the move towards abstract nil-values.  Before the nil in the case of `or` was the value `false`.  However, with the change resulution to the empty clause would return `alf.nil` instead of `false`.