### PR TITLE
Handle filepaths without C++ 17 filepath library

### DIFF
--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -6,6 +6,7 @@
 #include "base/check.h"
 #include "base/output.h"
 #include "state.h"
+#include "util/filesystem.h"
 
 namespace alfc {
 
@@ -201,11 +202,12 @@ void Compiler::setLiteralTypeRule(Kind k, const Expr& t)
   d_init << "  d_tc.setLiteralTypeRule(Kind::" << k << ", _e" << id << ");" << std::endl;
 }
 
-void Compiler::includeFile(const std::string& s)
+void Compiler::includeFile(const Filepath& s)
 {
   Assert (d_nscopes==0);
-  d_init << "  markIncluded(\"" << s << "\");" << std::endl;
-  d_config << "  ss << std::setw(15) << \" \" << \"" << s << "\" << std::endl;" << std::endl;
+  d_init << "  markIncluded(\"" << s.getRawPath() << "\");" << std::endl;
+  d_config << "  ss << std::setw(15) << \" \" << \"" << s.getRawPath()
+           << "\" << std::endl;" << std::endl;
 }
 
 void Compiler::bind(const std::string& name, const Expr& e)

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -3,15 +3,15 @@
 
 #include <map>
 #include <set>
-#include <string>
 #include <sstream>
-#include <filesystem>
+#include <string>
 
 #include "attr.h"
 #include "expr.h"
 #include "expr_info.h"
 #include "expr_trie.h"
 #include "type_checker.h"
+#include "util/filesystem.h"
 
 namespace alfc {
 
@@ -140,7 +140,7 @@ public:
   /** Pop scope */
   void popScope();
   /** include file, if not already done */
-  void includeFile(const std::string& s);
+  void includeFile(const Filepath& s);
   /** Set type rule for literal kind k to t */
   void setLiteralTypeRule(Kind k, const Expr& t);
   /** */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,11 +1,13 @@
-#include <fstream>
-#include <iostream>
 #include <unistd.h>
 
-#include "base/output.h"
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+
 #include "base/check.h"
-#include "state.h"
+#include "base/output.h"
 #include "parser.h"
+#include "state.h"
 
 using namespace alfc;
 

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -176,7 +176,7 @@ bool State::includeFile(const std::string& s, bool isReference, const Expr& refe
   {
     return true;
   }
-  Assert (!isReference || d_hasReference);
+  Assert (!isReference || !d_hasReference);
   d_hasReference = isReference;
   d_referenceNf = referenceNf;
   Filepath currentPath = d_inputFile;

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -5,6 +5,7 @@
 #include "base/check.h"
 #include "base/output.h"
 #include "parser.h"
+#include "util/filesystem.h"
 
 namespace alfc {
 
@@ -162,14 +163,15 @@ bool State::includeFile(const std::string& s)
 }
 bool State::includeFile(const std::string& s, bool isReference, const Expr& referenceNf)
 {
-  std::filesystem::path inputPath;
-  try {
-    inputPath = std::filesystem::canonical(d_inputFile.parent_path() / s);
-  }
-  catch (std::filesystem::filesystem_error const&)
+  Filepath inputPath = d_inputFile.parentPath();
+  inputPath.append(Filepath(s));
+  inputPath.makeCanonical();
+
+  if (!inputPath.exists())
   {
     return false;
   }
+
   if (!markIncluded(inputPath))
   {
     return true;
@@ -177,7 +179,7 @@ bool State::includeFile(const std::string& s, bool isReference, const Expr& refe
   Assert (!isReference || d_hasReference);
   d_hasReference = isReference;
   d_referenceNf = referenceNf;
-  std::filesystem::path currentPath = d_inputFile;
+  Filepath currentPath = d_inputFile;
   d_inputFile = inputPath;
   if (d_compiler!=nullptr)
   {
@@ -187,7 +189,7 @@ bool State::includeFile(const std::string& s, bool isReference, const Expr& refe
   Trace("state") << "Include " << inputPath << std::endl;
   Assert (getAssumptionLevel()==0);
   Parser p(*this, isReference);
-  p.setFileInput(inputPath);
+  p.setFileInput(inputPath.getRawPath());
   bool parsedCommand;
   do
   {
@@ -198,15 +200,16 @@ bool State::includeFile(const std::string& s, bool isReference, const Expr& refe
   Trace("state") << "...finished" << std::endl;
   if (getAssumptionLevel()!=0)
   {
-    ALFC_FATAL() << "Including file " << inputPath << " did not preserve assumption scope";
+    ALFC_FATAL() << "Including file " << inputPath.getRawPath()
+                 << " did not preserve assumption scope";
   }
   return true;
 }
 
-bool State::markIncluded(const std::string& s)
+bool State::markIncluded(const Filepath& s)
 {
-  std::set<std::filesystem::path>::iterator it = d_includes.find(s);
-  if (it!=d_includes.end())
+  std::set<Filepath>::iterator it = d_includes.find(s);
+  if (it != d_includes.end())
   {
     return false;
   }
@@ -1144,16 +1147,18 @@ bool State::markConstructorKind(const Expr& v, Attr a, const Expr& cons)
   {
     // use full path
     std::string ocmd = cons.getSymbol();
-    std::filesystem::path inputPath;
-    try {
-      inputPath = std::filesystem::canonical(d_inputFile.parent_path() / ocmd);
-    }
-    catch (std::filesystem::filesystem_error const&)
+
+    Filepath inputPath = d_inputFile.parentPath();
+    inputPath.append(Filepath(ocmd));
+    inputPath.makeCanonical();
+
+    if (!inputPath.exists())
     {
       Warning() << "State:: could not include \"" + ocmd + "\" for oracle definition";
       return false;
     }
-    acons = mkLiteral(Kind::STRING, inputPath);
+
+    acons = mkLiteral(Kind::STRING, inputPath.getRawPath());
   }
   Assert (isSymbol(v.getKind()));
   AppInfo& ai = d_appData[v.getValue()];

--- a/src/state.h
+++ b/src/state.h
@@ -5,16 +5,16 @@
 #include <set>
 #include <string>
 #include <unordered_map>
-#include <filesystem>
 
 #include "attr.h"
-#include "stats.h"
+#include "compiler.h"
 #include "expr.h"
 #include "expr_info.h"
 #include "expr_trie.h"
-#include "type_checker.h"
-#include "compiler.h"
 #include "literal.h"
+#include "stats.h"
+#include "type_checker.h"
+#include "util/filesystem.h"
 
 namespace alfc {
 
@@ -163,7 +163,7 @@ class State
   /** Get the constructor kind for symbol v */
   Attr getConstructorKind(const ExprValue* v) const;
   /** Mark that file s was included */
-  bool markIncluded(const std::string& s);
+  bool markIncluded(const Filepath& s);
   /** mark deleted */
   void markDeleted(ExprValue* e);
   /** Make (<APPLY> children), curried. */
@@ -226,9 +226,9 @@ class State
   // std::map<std::tuple<Kind, std::string, const ExprValue *>, Expr> d_symcMap;
   //--------------------- includes
   /** input file */
-  std::filesystem::path d_inputFile;
+  Filepath d_inputFile;
   /** Cache of files included */
-  std::set<std::filesystem::path> d_includes;
+  std::set<Filepath> d_includes;
   /** Have we parsed a reference file to check assumptions? */
   bool d_hasReference;
   /** The reference normalization function, if it exists */

--- a/src/util/filesystem.cpp
+++ b/src/util/filesystem.cpp
@@ -1,0 +1,174 @@
+#include "util/filesystem.h"
+
+#include <fstream>
+#include <sstream>
+#include <vector>
+
+#include "base/check.h"
+
+namespace alfc {
+Filepath::Filepath() {}
+
+Filepath::Filepath(std::string rawPath)
+{
+  /* Trim the input path */
+  size_t first = rawPath.find_first_not_of(' ');
+  if (std::string::npos == first)
+  {
+    this->rawPath = rawPath;
+    return;
+  }
+  size_t last = rawPath.find_last_not_of(' ');
+  this->rawPath = rawPath.substr(first, (last - first + 1));
+}
+
+Filepath::Filepath(const char* rawPath)
+{
+  std::string path = std::string(rawPath);
+  /* Trim the input path */
+  size_t first = path.find_first_not_of(' ');
+  if (std::string::npos == first)
+  {
+    this->rawPath = path;
+    return;
+  }
+  size_t last = path.find_last_not_of(' ');
+  this->rawPath = path.substr(first, (last - first + 1));
+}
+
+Filepath::~Filepath() {}
+
+bool Filepath::isAbsoluste() const
+{
+#ifdef _WIN32
+  static_assert(false, "File system support for Windows not implemented.");
+#endif
+  return rawPath[0] == '/';
+}
+
+bool Filepath::exists() const
+{
+  std::ifstream f;
+  return f.good();
+}
+
+void Filepath::append(const Filepath path) { rawPath.append(path.rawPath); }
+
+void Filepath::makeCanonical()
+{
+#ifdef _WIN32
+  static_assert(false, "File system support for Windows not implemented.");
+#endif
+
+  if (rawPath.length() == 0)
+  {
+    return;
+  }
+
+  size_t start = 0;
+  size_t parent_prefix_len = 0;
+  bool is_absolute = false;
+
+  std::vector<std::pair<size_t, size_t>> segments;
+  while (true)
+  {
+    size_t next = rawPath.find('/', start);
+    if (next >= rawPath.length())
+    {
+      // Done
+      size_t len = rawPath.length() - start;
+      segments.push_back(std::pair(start, len));
+      break;
+    }
+    if (next == 0)
+    {
+      is_absolute = true;
+      start = 1;
+      continue;
+    }
+    size_t len = next - start;
+    // Empty segment
+    if (len == 0)
+    {
+      start = next + 1;
+      continue;
+    }
+    // "current folder"
+    if (rawPath.compare(start, len, ".") == 0)
+    {
+      start = next + 1;
+      continue;
+    }
+    // "parent folder"
+    if (rawPath.compare(start, len, "..") == 0)
+    {
+      start = next + 1;
+      if (segments.empty())
+      {
+        parent_prefix_len += 1;
+      }
+      else
+      {
+        // Pop segment
+        segments.pop_back();
+      }
+      continue;
+    }
+    segments.push_back(std::pair(start, len));
+    start = next + 1;
+  }
+
+  std::stringstream newPath;
+  bool first = true;
+
+  if (is_absolute)
+  {
+    newPath << "/";
+  }
+
+  for (size_t i = 0; i < parent_prefix_len; i++)
+  {
+    newPath << "../";
+  }
+
+  for (auto it = segments.begin(); it != segments.end(); it++)
+  {
+    if (!first)
+    {
+      newPath << "/";
+    }
+    newPath << rawPath.substr(it->first, it->second);
+    first = false;
+  }
+  rawPath = newPath.str();
+}
+
+Filepath Filepath::parentPath() const
+{
+#ifdef _WIN32
+  static_assert(false, "File system support for Windows not implemented.");
+#endif
+
+  size_t last = this->rawPath.find_last_of("/");
+  // If there are no folders, the parent is the empty string
+  if (last == std::string::npos)
+  {
+    return Filepath("");
+  }
+  std::string newPath = this->rawPath.substr(0, last + 1);
+  return Filepath(newPath);
+}
+
+std::string Filepath::getRawPath() const { return this->rawPath; }
+
+bool operator<(const Filepath& a, const Filepath& b)
+{
+  return a.getRawPath() < b.getRawPath();
+}
+
+std::ostream& operator<<(std::ostream& os, const Filepath& obj)
+{
+  os << obj.getRawPath() << '\n';
+  return os;
+}
+}  // namespace alfc

--- a/src/util/filesystem.h
+++ b/src/util/filesystem.h
@@ -1,0 +1,32 @@
+#ifndef FILEYSTEM_H
+#define FILEYSTEM_H
+
+#include <string>
+
+namespace alfc {
+class Filepath
+{
+ public:
+  Filepath();
+  Filepath(std::string rawPath);
+  Filepath(const char* rawPath);
+
+  ~Filepath();
+
+  bool isAbsoluste() const;
+  bool exists() const;
+  void append(const Filepath);
+  void makeCanonical();
+  Filepath parentPath() const;
+  std::string getRawPath() const;
+
+ private:
+  std::string rawPath;
+};
+
+bool operator<(const Filepath&, const Filepath&);
+std::ostream& operator<<(std::ostream&, const Filepath&);
+
+}  // namespace alfc
+
+#endif /* FILESYSTEM_H */

--- a/src/util/filesystem.h
+++ b/src/util/filesystem.h
@@ -3,6 +3,14 @@
 
 #include <string>
 
+#ifndef USE_STANDALONE_FILESYSTEM
+#define USE_CPP_FILESYSTEM
+#endif
+
+#ifdef USE_CPP_FILESYSTEM
+#include <filesystem>
+#endif
+
 namespace alfc {
 
 /**
@@ -62,7 +70,11 @@ class Filepath
   std::string getRawPath() const;
 
  private:
+#ifndef USE_CPP_FILESYSTEM
   std::string rawPath;
+#else
+  std::filesystem::path rawPath;
+#endif
 };
 
 bool operator<(const Filepath&, const Filepath&);

--- a/src/util/filesystem.h
+++ b/src/util/filesystem.h
@@ -4,20 +4,61 @@
 #include <string>
 
 namespace alfc {
+
+/**
+ * Simple handler for filepaths.  Only supports Unix-style paths for
+ * now.  Does not use C++ 17 features.
+ */
 class Filepath
 {
  public:
   Filepath();
+
+  /**
+   * @param rawPath A string of the filepath.
+   */
   Filepath(std::string rawPath);
+
+  /**
+   * @param rawPath A C-style string of the filepath.
+   */
   Filepath(const char* rawPath);
 
   ~Filepath();
 
+  /**
+   * @return `true` if the current path starts with '/'.
+   */
   bool isAbsoluste() const;
+
+  /**
+   * @return `true` the current path points to an existing file.
+   */
   bool exists() const;
-  void append(const Filepath);
+
+  /**
+   * Appends a path to this path.  Does not do any normalization.
+   * @param path is the path to append.
+   */
+  void append(const Filepath path);
+
+  /**
+   * This removes segments of the path that are superflous:
+   *   - Repeated slashes: "//"
+   *   - Parten folders, not at the start.  "foo/../bar" becomes
+   *     "bar", but "../baz" is unchanged.
+   *   - Curent folder segments. "foo/./bar" becomes "foo/bar".
+   */
   void makeCanonical();
+
+  /**
+   * @return The current path, but with the filename cut off.
+   */
   Filepath parentPath() const;
+
+  /**
+   * @return A copy of the underlying string.
+   */
   std::string getRawPath() const;
 
  private:


### PR DESCRIPTION
This adds a naive filepath handler that doesn't rely on the C++ filepath API.

Should throw an error when run on Windows.  I think in the future we should detect if the filepath API is available (how?) and use that one in case it is.